### PR TITLE
switch dimensions in HDF5 files (dim[0] is height, dim[1] width)

### DIFF
--- a/include/Scheduler.hxx
+++ b/include/Scheduler.hxx
@@ -85,6 +85,7 @@ public:
 
 	//! basic method to use while exploring boundaries of World 
 	virtual const Rectangle<int> & getBoundaries() const { return _boundaries; };
+	virtual const Rectangle<int> & getOwnedArea() const { return _boundaries; };
 	virtual Point2D<int> getRandomPosition() const = 0;
 
 	// ids

--- a/include/SpacePartition.hxx
+++ b/include/SpacePartition.hxx
@@ -146,7 +146,6 @@ class SpacePartition : public Scheduler
 	//! send overlapping data to neighbours before run
 	void initOverlappingData();
 
-	const Rectangle<int> & getOwnedArea() const;
 	//! returns the attribute _overlap
 	const int & getOverlap() const;
 	//! transform from global coordinates to real coordinates (in terms of world position)
@@ -159,6 +158,7 @@ public:
 	void finish();
 
 	const Rectangle<int> & getBoundaries() const;
+	const Rectangle<int> & getOwnedArea() const;
 	//! initialization of the object World for the simulation. Required to be called before calling run.
 
 	//! initializes everything needed before creation of agents and rasters (i.e. sizes)

--- a/include/World.hxx
+++ b/include/World.hxx
@@ -164,6 +164,7 @@ public:
 	  * but if this is not the case it is the area owned by the instance plus the overlaps
 	  */
 	const Rectangle<int> & getBoundaries() const;
+	const Rectangle<int> & getOwnedArea() const;
 
 	// methods that need to be defined for current state of the code
 	AgentsList::iterator beginAgents() { return _agents.begin(); }

--- a/src/RasterLoader.cxx
+++ b/src/RasterLoader.cxx
@@ -181,19 +181,20 @@ void RasterLoader::fillHDF5RasterDirectPath( StaticRaster & raster, const std::s
 			for(index._y=boundaries._origin._y; index._y<boundaries._origin._y+boundaries._size._height; index._y++)
 			{
 				Point2D<int> index2(index - boundaries._origin);
-				int index = boundaries._size._width*index2._y+index2._x;
+				int index = index2._y+boundaries._size._height*index2._x;
 				raster._values[index2._x][index2._y] = (int)dset_data[index];
 			}
 		}
 	}
 	else
 	{
-		for(size_t i=0; i<dims[0]; i++)
+		size_t index = 0;
+		for(size_t y=0; y<dims[0]; y++)
 		{
-			for(size_t j=0; j<dims[1]; j++)
+			for(size_t x=0; x<dims[1]; x++)
 			{
-				size_t index = i+j*dims[0];
-				raster._values[i][j] = dset_data[index];	
+				raster._values[x][y] = dset_data[index];	
+				++index;
 			}
 		}
 	}

--- a/src/SequentialSerializer.cxx
+++ b/src/SequentialSerializer.cxx
@@ -194,8 +194,8 @@ void SequentialSerializer::init( World & world )
 	
 	//the real size of the matrix is sqrt(num simulator)*matrixsize	
 	hsize_t dimensions[2];
-	dimensions[0] = hsize_t(_config->getSize()._width);
-	dimensions[1] = hsize_t(_config->getSize()._height);
+	dimensions[0] = hsize_t(_config->getSize()._height);
+	dimensions[1] = hsize_t(_config->getSize()._width);
 
 	// static rasters	
 	for(size_t i=0; i<world.getNumberOfRasters(); i++)
@@ -598,23 +598,23 @@ void SequentialSerializer::serializeRaster( const StaticRaster & raster, const s
 	hid_t dataSetId = H5Dopen(_fileId, datasetKey.c_str(), H5P_DEFAULT);
 	hid_t fileSpace = H5Dget_space(dataSetId);
 
+	const hsize_t ownedAreaWidth = _scheduler.getOwnedArea()._size._width;
+	const hsize_t ownedAreaHeight = _scheduler.getOwnedArea()._size._height;
+ 
 	hsize_t	block[2];
-	block[0] = _scheduler.getBoundaries()._size._width;
-	block[1] = _scheduler.getBoundaries()._size._height;
+	block[0] = ownedAreaHeight;
+	block[1] = ownedAreaWidth;
 	
 	int * data = (int *) malloc(sizeof(int)*block[0]*block[1]);
-	for(size_t i=0; i<block[0]; i++)
+	size_t index = 0;
+	for(size_t y=0; y<ownedAreaHeight; y++)
 	{
-		for(size_t j=0; j<block[1]; j++)
+		for(size_t x=0; x<ownedAreaWidth; x++)
 		{	
-			size_t index = j*block[0]+i;
-			log_EDEBUG(logName.str(), "index: " << i << "/" << j << " - " << index);
-			/*
-			log_EDEBUG(logName.str(), "getting value: " << Point2D<int> (i+overlapDist._x,j+overlapDist._y));
-			data[index] = raster.getValue(Point2D<int> (i+overlapDist._x,j+overlapDist._y));
-			*/
-			data[index] = raster.getValue(Point2D<int>(i,j));
+			log_EDEBUG(logName.str(), "index: " << x << "/" << y << " - " << index);
+			data[index] = raster.getValue(Point2D<int>(x,y));
 			log_EDEBUG(logName.str(), "value: " << data[index]);
+			++index;
 		}
 	}
     // Create property list for collective dataset write.

--- a/src/Serializer.cxx
+++ b/src/Serializer.cxx
@@ -687,9 +687,6 @@ void Serializer::serializeRaster( const StaticRaster & raster, const std::string
 			log_EDEBUG(logName.str(), "index: " << x << "/" << y << " - " << index);
 			log_EDEBUG(logName.str(), "getting value: " << Point2D<int> (x+overlapDist._x,y+overlapDist._y));
 			data[index] = raster.getValue(Point2D<int> (x+overlapDist._x,y+overlapDist._y));
-			if (data[index] < -100) {
-				log_INFO(logName.str(), "low value: " << data[index] << " at pos: " << x << "/" << y);
-			}
 			log_EDEBUG(logName.str(), "value: " << data[index]);
 			++index;
 		}

--- a/src/SimulationRecord.cxx
+++ b/src/SimulationRecord.cxx
@@ -186,18 +186,18 @@ bool SimulationRecord::loadHDF5( const std::string & fileName, const bool & load
 					
 					// squared	
 					DynamicRaster & raster = it->second[i/getFinalResolution()];
-					raster.resize(Size<int>(dims[0], dims[1]));
+					raster.resize(Size<int>(dims[1], dims[0]));
 					// TODO max value!
 					raster.setInitValues(std::numeric_limits<int>::min(),std::numeric_limits<int>::max(), 0);
 
 					H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, dset_data);
 					H5Dclose(dset_id);
 
-					for(size_t i=0; i<dims[0]; i++)
+					size_t index = 0;
+					for(size_t y=0; y<dims[0]; y++)
 					{
-						for(size_t j=0; j<dims[1]; j++)
+						for(size_t x=0; x<dims[1]; x++)
 						{
-							size_t index = i+j*dims[0];
 							int value = dset_data[index];
 							if(value>raster.StaticRaster::getMaxValue())
 							{
@@ -215,8 +215,9 @@ bool SimulationRecord::loadHDF5( const std::string & fileName, const bool & load
 							{
 								minValue = value;
 							}
-							raster.setMaxValue(Point2D<int>(i,j), value);
-							raster.setValue(Point2D<int>(i,j), value); 
+							raster.setMaxValue(Point2D<int>(x,y), value);
+							raster.setValue(Point2D<int>(x,y), value); 
+							++index;
 						}
 					}
 					free(dset_data);

--- a/src/World.cxx
+++ b/src/World.cxx
@@ -424,6 +424,7 @@ Scheduler * World::useOpenMPSingleNode()
 const int & World::getId() const { return _scheduler->getId(); }
 const int & World::getNumTasks() const { return _scheduler->getNumTasks(); }
 const Rectangle<int> & World::getBoundaries() const{ return _scheduler->getBoundaries(); }
+const Rectangle<int> & World::getOwnedArea() const{ return _scheduler->getOwnedArea(); }
 void World::removeAgent( std::shared_ptr<Agent> agentPtr )
 {
     Agent * agent = agentPtr.get();


### PR DESCRIPTION
As shown e.g. here: https://www.hdfgroup.org/HDF5/Tutor/selectsimple.html, the default in HDF5 is to interpret Dim 0 as rows and Dim 1 as columns in the 2-dimensional case. In Pandora it is the other way (Dim 0 is the width, Dim 1 the height). I switched this, and hopefully found all cases where this is relevant.
